### PR TITLE
UI bug fixes

### DIFF
--- a/RuneApp/Main.cs
+++ b/RuneApp/Main.cs
@@ -501,8 +501,12 @@ namespace RuneApp {
 			if (runeDial.RuneSelected == 0)
 				return;
 
-			var r = l.Runes[runeDial.RuneSelected - 1];
-			runeEquipped.SetRune(r);
+			if (l == null) {
+				runeEquipped.SetRune(null);
+            } else {
+				var r = l.Runes[runeDial.RuneSelected - 1];
+				runeEquipped.SetRune(r);
+			}
 		}
 
 		private void lbCloseEquipped_Click(object sender, EventArgs e) {

--- a/RuneApp/Program.cs
+++ b/RuneApp/Program.cs
@@ -656,6 +656,9 @@ namespace RuneApp {
 		}
 
 		public static void StopBuild() {
+			// no build selected, no build running
+			if (currentBuild == null)
+				return;
 			runSource?.Cancel();
 			if (currentBuild.runner != null) {
 				currentBuild.runner.Cancel();


### PR DESCRIPTION
This fixes two UI bugs I ran into in Debug mode:

1. Fixes Issue #74 
2. If you try to click "run loadout" without selecting anything and without anything running, it throws an error.  I just ignore the condition.  Could be better to pop up a dialog that says "please select a rune".