### PR TITLE
Update Loadout Rune Info

### DIFF
--- a/RuneApp/Program.cs
+++ b/RuneApp/Program.cs
@@ -310,11 +310,20 @@ namespace RuneApp {
 				// TODO: temp fix
 				// this probably is somewhat of a leak, as the loadouts will have references to runes no-longer in the save (because the list was recreated in-place).
 				foreach (var l in Program.loads) {
-					foreach (var rid in l.RuneIDs) {
-						var rr = Program.data.Runes.FirstOrDefault(r => r.Id == rid);
+					for (int i = 0; i < 6; i++) {
+						if (l.Runes[i] == null)
+							continue;
+						var rr = Program.data.Runes.FirstOrDefault(r => r.Id == l.Runes[i].Id);
 						if (rr != null)
-							rr.Locked = true;
+                        {
+							l.Runes[i] = rr;
+						} else
+                        {
+							l.Runes[i].AssignedId = 0;
+							l.Runes[i].AssignedName = "RUNE MISSING";
+                        }
 					}
+					l.Lock();
 				}
 
 				//var bakemons = data.Monsters.Where(mo => !data.Monsters.Any(o => o.monsterTypeId == mo.monsterTypeId && o.Grade > 4));


### PR DESCRIPTION
This is a (partial) solution to #66 that updates Loadouts to use refreshed runes.  There are a couple of caveats:

1. If a rune is deleted, the cache was breaking because the loadout was invalid.  To work around this, the old rune is retained but the source is updated to "RUNE MISSING"
2. The loadouts UI element is not updated.  The problem is that I need to call `Loadout.RecountDiff`.  Unfortunately, this method takes `monId` as a parameter and l don't see a backlink from a loadout in `Program.loads` to its mon.  In [other parts of the code](https://github.com/Skibisky/RuneManager/blob/master/RuneApp/Main.cs#L599) `monId` is extracted from the UI element rather than the loadout.

In theory, I could probably iterate `loadoutList` instead of `Program.loads` but the data structure should probably be fixed.  The simplest option is to store the mon in the `Loadout`.  Since it should be possible to apply a particular `Loadout` to any monster, it may actually be better to create and pass around a `MonsterLoadout` that includes references to the two pieces but does not otherwise couple them.