### PR TITLE
Update Loadout Pane

### DIFF
--- a/RuneApp/Main.Functions.cs
+++ b/RuneApp/Main.Functions.cs
@@ -382,6 +382,18 @@ namespace RuneApp {
 				dataRuneList.Sort();
 			}
 		}
+		public void refreshLoadouts()
+		{
+			foreach (ListViewItem item in loadoutList.Items)
+			{
+				Loadout load = (Loadout)item.Tag;
+
+				var monid = ulong.Parse(item.SubItems[2].Text);
+
+				load.RecountDiff(monid);
+				ListViewItemLoad(item, load);
+			}
+		}
 
 		public void checkLocked() {
 			if (Program.data?.Runes == null)

--- a/RuneApp/Main.cs
+++ b/RuneApp/Main.cs
@@ -855,6 +855,7 @@ namespace RuneApp {
 			if (File.Exists(Program.Settings.SaveLocation)) {
 				Program.LoadSave(Program.Settings.SaveLocation);
 				RebuildLists();
+				refreshLoadouts();
 			}
 		}
 


### PR DESCRIPTION
This addresses the rest of #66 by updating the loadout pane as well.  It uses the "workaround" strategy of iterating `loadoutList`.  If you want to refactor `Loadout` into something more sophisticated (perhaps with separate links to `Loadout`, `Monster`, and `LeaderSkill`, you can make an issue for it.  Since that's only refactoring (and doesn't affect current functionality), I'm not going to clutter the Issue list.