### PR TITLE
WIP:  Simplification/Refactor

### DIFF
--- a/RuneApp/BuildPlan.cs
+++ b/RuneApp/BuildPlan.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RuneOptim.BuildProcessing;
+using RuneOptim.Management;
+using RuneOptim.swar;
+
+namespace RuneApp
+{
+    class BuildPlanConfig
+    {
+        public int minImprovement = 0;
+        public bool fillOnly = false;
+    }
+
+    class BuildPlan
+    {
+        public enum BuildStrategies
+        {
+            Skip = 0,  // monster should end up unruned
+            Lock = -1,  // monster retains current runes
+            Build = 1,  // iterate through enabled build until one succeeds
+        } 
+
+        private BuildStrategies _buildStrategy = BuildStrategies.Build;
+        public BuildStrategies buildStrategy
+        {
+            get
+            {
+                return _buildStrategy;
+            }
+            set
+            {
+                _buildStrategy = value;
+                if (_buildStrategy == BuildStrategies.Lock)
+                {
+                    if (monster != null)
+                        best = monster.Current;
+                }
+                else if (_buildStrategy == BuildStrategies.Skip)
+                {
+                    best = new Loadout();
+                }
+            }
+        }
+
+        private Monster _monster;
+        public Monster monster
+        {
+            get
+            {
+                return _monster;
+            }
+            set
+            {
+                _monster = value;
+                if (buildStrategy == BuildStrategies.Lock)
+                    best = monster.Current;
+            }
+        }
+
+        public BuildPlanConfig config;
+        // each build is configured with a leader (appropriate to their situation)
+        public Build[] builds;
+        public Loadout best;
+    }
+}

--- a/RuneApp/RuneApp.csproj
+++ b/RuneApp/RuneApp.csproj
@@ -106,6 +106,7 @@
     <Compile Include="BuildWizard.Designer.cs">
       <DependentUpon>BuildWizard.cs</DependentUpon>
     </Compile>
+    <Compile Include="BuildPlan.cs" />
     <Compile Include="Controls\ControlHolder.cs" />
     <Compile Include="Controls\ControlMap.cs" />
     <Compile Include="Controls\RichTextBoxEx.cs">


### PR DESCRIPTION
This is a work-in-progress branch (WIP) for discussing a more significant change like I propose in #37.  I'm now proposing to go even further and consolidate all three tables into one.   That one table has 3 types of columns:

1. Monster details (stars, level, name)
2. Build strategy (!, skip, locked, build -- see below)
3. Loadout status (! vs. done vs. partial, swap, up, time -- similar to the current loadout status

The refactor would also change/enhance the way builds are handled (initial code demonstration included).

- Each mon could have 0...* builds.  The builds can be prioritized and enabled/disabled.  
    - When a build is run, it works in priority order through enabled builds until it finds a valid build.
    - This can be used to preserve builds for different situations or e.g. to create a fallback order. For example, 
        - The advice for GB10 used to be 190 Vio or 220 Swift.  Build 1 could be 190 Vio.  Build 2 could be 220 swift.  There's no way to do this today.
        - You could do the same with e.g. Nem.  A 250 SPD build with Nem or 270 without.
- Separate from the list of builds is a `buildStrategy`.  This can be toggled among Skip, Lock, and Build.  Today you lose the build every time you lock the monster.  If "build" is selected, the column will show "Build (#)" indicating the number of enabled builds.
- Each build strategy (per mon) is also configured (per monster) with options like "Fill Only" or "Minimum improvement to change runes"
- The monster, builds, strategy configurations, and first/best loadout are stored on this object (as demonstrated in the attached).

Besides a massive consolidation on the homescreen, not much else needs to change.  

 - I'd probably add an extra layer of UI that configures the Build Strategy and lets you access each of the builds.  This pane could also offer an "import" feature that lets you pick a variety of suggested builds (e.g. generic "bruiser" or GB12 Tatu)
 - I've kicked around the possibility of not listing all monsters and having an "add" button that grabs them from your pool.
 - I like tracking teams (especially when I have dupes).  I find the current column too small.  I'm not sure if I want to suggest wasting more horizontal room or what.

At minimum, eliminating 2/3 of the columns for monster names, 1/2 of priority columns, and the extra spacer/scrolls should compact the information.  Having the UI render a `BuildStrategy` also ensures that a data object keeps track of all of these relationships (rather than some of the UI list workarounds).