### PR TITLE
Double Wrap Locked Builds

### DIFF
--- a/RuneClasses/BuildProcessing/Build.Old.cs
+++ b/RuneClasses/BuildProcessing/Build.Old.cs
@@ -405,7 +405,7 @@ namespace RuneOptim.BuildProcessing {
         [Obsolete]
         public BuildResult GenBuilds(string prefix = "") {
             if (Type == BuildType.Lock) {
-                Best = new Monster(Mon, true);
+                Best = new Monster(new Monster(Mon), true);
                 return BuildResult.Success;
             }
             else if (Type == BuildType.Link) {


### PR DESCRIPTION
This PR fixes #99 by replicating the layers of `Monster()` in the normal build:

1. When [`test` is created](https://github.com/Skibisky/RuneManager/blob/1c54e07fe7bfbf0b7208a94b6eae31072705d395/RuneClasses/BuildProcessing/Build.Old.cs#L642)
2. When [`test` become `Best`](https://github.com/Skibisky/RuneManager/blob/1c54e07fe7bfbf0b7208a94b6eae31072705d395/RuneClasses/BuildProcessing/Build.Old.cs#L946)

This double-wrapping of the original mon seems to be the root cause of #99 so this double-wraps a locked build to achieve the same internal state.